### PR TITLE
fix: don't overwrite namespaces when importing rules in existing ones

### DIFF
--- a/client/src/test/diagnostics.test.ts
+++ b/client/src/test/diagnostics.test.ts
@@ -12,8 +12,9 @@ import { getDocUri, activate, mainUri, mainPath } from "./helper";
  * 4. For each test:
  *   a. copy the content of the test document to the main document,
  *   b. save the main document and wait for the diagnostics to be computed.
+ *
+ * TODO: Add at least one test for each diagnostic (need to support multiple files).
  */
-
 suite("Should get diagnostics", () => {
   test("Missing name in import macros", async () => {
     await testDiagnostics(getDocUri("diagnostics-import.publicodes"), [

--- a/server/src/semanticTokens.ts
+++ b/server/src/semanticTokens.ts
@@ -166,7 +166,6 @@ function collectTokens(
       case "plafond":
       case "arrondi":
       case "montant":
-      case "dans":
       case "références_à":
       case "sauf_dans":
       case "choix_obligatoire":
@@ -231,6 +230,21 @@ function collectTokens(
           [SemanticTokenModifiers.readonly],
         );
         break;
+      }
+
+      case "import": {
+        const intoNode = node.childForFieldName("into");
+        if (intoNode && intoNode.type === "dotted_name") {
+          intoNode.children.forEach((name) => {
+            pushToken(
+              builder,
+              name.startPosition.row,
+              name.startPosition.column,
+              name.endPosition.column - name.startPosition.column,
+              SemanticTokenTypes.namespace,
+            );
+          });
+        }
       }
 
       case "import_rule":

--- a/server/src/validate.ts
+++ b/server/src/validate.ts
@@ -7,6 +7,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { Logger } from "publicodes";
 import { mapAppend, positionToRange } from "./helpers";
 import { getRefInRule } from "./treeSitter";
+import { getModelFromSource } from "@publicodes/tools/compilation";
 
 export default async function validate(
   ctx: LSContext,
@@ -22,13 +23,9 @@ export default async function validate(
   try {
     // Merge all raw rules (from all files) into one object
     // NOTE: a better way could be found?
-    ctx.rawPublicodesRules = {};
-    ctx.fileInfos.forEach((fileInfo) => {
-      ctx.rawPublicodesRules = {
-        ...ctx.rawPublicodesRules,
-        ...fileInfo.rawRules,
-      };
-    });
+
+    const globFiles = [...ctx.fileInfos.keys()];
+    ctx.rawPublicodesRules = getModelFromSource(globFiles);
 
     let startTimer = Date.now();
     ctx.engine = new Engine(ctx.rawPublicodesRules, {


### PR DESCRIPTION
Fix #16 

We consider now all files for duplicates check from `getModelFromSource`